### PR TITLE
Use non-dummy application name.

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">MainLauncher</string>
+    <string name="app_name">TV Launcher</string>
 </resources>


### PR DESCRIPTION
A user usually doesn't see launcher name, but when you install a new
launcher, system shows a list of all launchers available, and having
dummy name there is confusing.
